### PR TITLE
Add unit declarator to class and role declarations

### DIFF
--- a/lib/Web/App/MVC.pm6
+++ b/lib/Web/App/MVC.pm6
@@ -1,6 +1,6 @@
 use Web::App::Dispatch;
 
-class Web::App::MVC is Web::App::Dispatch;
+unit class Web::App::MVC is Web::App::Dispatch;
 
 use JSON::Tiny;
 

--- a/lib/Web/App/MVC/Controller.pm6
+++ b/lib/Web/App/MVC/Controller.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Web::App::MVC::Controller;
+unit class Web::App::MVC::Controller;
 
 has $.app handles <get-model>;      ## Web::App::MVC instance.
 has $.views;                        ## Template engine to use for views.

--- a/lib/Web/App/MVC/Controller/MethodDispatch.pm6
+++ b/lib/Web/App/MVC/Controller/MethodDispatch.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-role Web::App::MVC::Controller::MethodDispatch;
+unit role Web::App::MVC::Controller::MethodDispatch;
 
 ## If your controller class is to be used as a default
 ## controller, then set the $!default to one of:


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.