### PR TITLE
Fix removed @*INC

### DIFF
--- a/test/test1.p6
+++ b/test/test1.p6
@@ -1,6 +1,6 @@
 use v6;
 
-BEGIN { @*INC.push: './lib', './test'; }
+use lib <test lib>;
 
 use Web::App::MVC;
 use Test1::Controllers::Default;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.