### PR TITLE
fix syntax problem

### DIFF
--- a/lib/Web/App/MVC.pm6
+++ b/lib/Web/App/MVC.pm6
@@ -24,7 +24,7 @@ method new (*%opts) {
     my %cx = %config<connector>;
     if not %cx<type>:exists { die "no type specified in connector configuration" }
     my $type = %cx<type>;
-    my %copts = {};
+    my %copts := {};
     for %cx.keys -> $cxopt {
       if $cxopt ne 'type' {
         %copts{$cxopt} = %cx{$cxopt}; 


### PR DESCRIPTION
change should fix:
```
root@rakudo-star-201801:/workdir# perl6 -I lib test/test1.p6
Potential difficulties:                                                            
    Useless use of hash composer on right side of hash assignment; did you mean := instead?
    at /workdir/lib/Web/App/MVC.pm6 (Web::App::MVC):27     
    ------>     my %copts = {}⏏;

```