### PR TITLE
fix problem with bless

### DIFF
--- a/lib/Web/App/MVC.pm6
+++ b/lib/Web/App/MVC.pm6
@@ -59,7 +59,7 @@ method new (*%opts) {
   else {
     die "no connector specified";
   }
-  return self.bless(*, :$engine, :%config);
+  return self.bless(:$engine, :%config);
 }
 
 ## Load an on-demand configuration.


### PR DESCRIPTION
This change should fix:
```
root@rakudo-star-201801:/workdir# perl6 -I lib test/test1.p6
Too many positionals passed; expected 1 argument but got 2
  in method new at /workdir/lib/Web/App/MVC.pm6 (Web::App::MVC) line 62
  in block <unit> at test/test1.p6 line 9
```